### PR TITLE
Encrypt Token Response from Server

### DIFF
--- a/rancher/rancher.go
+++ b/rancher/rancher.go
@@ -26,6 +26,7 @@ func NewRancherClientFromContainerEnv() (*client.RancherClient, error) {
 }
 
 func GetRancherHostPublicKey(rClient *client.RancherClient, hostUUID string) (string, error) {
+	// TODO: add a cache here possibly use hashicorp/lru
 	hosts, err := rClient.Host.List(&client.ListOpts{
 		Filters: map[string]interface{}{
 			"uuid": hostUUID,

--- a/scripts/build
+++ b/scripts/build
@@ -8,3 +8,5 @@ cd $(dirname $0)/..
 mkdir -p bin
 [ "$(uname)" != "Darwin" ] && LINKFLAGS="-linkmode external -extldflags -static -s"
 CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/vault-volume-driver-server
+
+cd $(dirname $0)

--- a/server/tokens.go
+++ b/server/tokens.go
@@ -2,15 +2,23 @@ package server
 
 import (
 	"github.com/rancher/go-rancher/client"
+	"github.com/rancher/secrets-api/pkg/rsautils"
 )
 
 // NewVaultTokenResponse returns a VaultIntermedateTokenResponse object
-func NewVaultTokenResponse(intermediateToken *IntermediateToken) *VaultIntermediateTokenResponse {
-	return &VaultIntermediateTokenResponse{
+func NewVaultTokenResponse(intermediateToken *IntermediateToken, pubKey string) (*VaultIntermediateTokenResponse, error) {
+	resp := &VaultIntermediateTokenResponse{
 		Resource: client.Resource{
 			Type: "vaultIntermediateToken",
 		},
 		Accessor: intermediateToken.Accessor,
-		Token:    intermediateToken.Token,
 	}
+
+	pubKeyEncryptor, err := rsautils.PublicKeyFromString(pubKey)
+	if err != nil {
+		return resp, err
+	}
+
+	resp.EncryptedToken, err = pubKeyEncryptor.Encrypt(intermediateToken.Token)
+	return resp, err
 }

--- a/server/types.go
+++ b/server/types.go
@@ -19,10 +19,17 @@ type VaultTokenInput struct {
 	TimeStamp string `json:"timestamp"`
 }
 
+type verifiedVaultTokenInput struct {
+	Policies  string
+	PublicKey string
+}
+
 type VaultIntermediateTokenResponse struct {
 	client.Resource
-	Token    string `json:"token"`
-	Accessor string `json:"accessor"`
+	// EncryptedToken is the Vault Token RSA Encrypted with the hosts public key.
+	// This prevents replay attacks from another host.
+	EncryptedToken string `json:"encryptedToken"`
+	Accessor       string `json:"accessor"`
 }
 
 type VaultTokenExpireInput struct {

--- a/signature/sign.go
+++ b/signature/sign.go
@@ -7,10 +7,10 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/pem"
-	"errors"
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/rancher/secrets-api/pkg/rsautils"
 )
 
 const (
@@ -56,20 +56,8 @@ func LoadPrivateKeyFromString(key string) (*rsa.PrivateKey, error) {
 }
 
 func LoadRSAPublicKey(key string) (*rsa.PublicKey, error) {
-	block, val := pem.Decode([]byte(key))
-	if block == nil {
-		logrus.Debugf(string(val))
-		return nil, errors.New("could not decode public key block")
-	}
-
-	logrus.Debugf("Public Key Block Type: %s", block.Type)
-
-	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
-	if err != nil {
-		return nil, err
-	}
-
-	return pub.(*rsa.PublicKey), nil
+	rsakey, err := rsautils.PublicKeyFromString(key)
+	return rsakey.PublicKey, err
 }
 
 func timeWindowExpired(ts *time.Time) bool {

--- a/vendor.conf
+++ b/vendor.conf
@@ -28,3 +28,4 @@ golang.org/x/text/unicode/norm     master
 golang.org/x/text/transform        master
 github.com/moby/moby/pkg/mount     v1.12.6
 github.com/rancher/go-rancher-metadata d2103caca5873119ff423d29cba09b4d03cd69b8
+github.com/rancher/secrets-api/pkg/rsautils f8b1dacbb9c0af24e489f3bf0abf2f92b0561784

--- a/vendor/github.com/rancher/secrets-api/pkg/rsautils/publickey.go
+++ b/vendor/github.com/rancher/secrets-api/pkg/rsautils/publickey.go
@@ -1,0 +1,49 @@
+package rsautils
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+
+	"github.com/Sirupsen/logrus"
+)
+
+// RSAPublicKey a struct to hold an RSA Public Key
+type RSAPublicKey struct {
+	*rsa.PublicKey
+}
+
+// PublicKeyFromString returns an RSA public key object from a string
+func PublicKeyFromString(pKey string) (*RSAPublicKey, error) {
+	key, err := loadRSAPublicKey(pKey)
+	return &RSAPublicKey{key}, err
+}
+
+// Encrypt uses RSA Public key to encrypt data
+func (pk *RSAPublicKey) Encrypt(text string) (string, error) {
+	rng := rand.Reader
+	cipherText, err := rsa.EncryptOAEP(sha256.New(), rng, pk.PublicKey, []byte(text), []byte(""))
+
+	return base64.StdEncoding.EncodeToString(cipherText), err
+}
+
+func loadRSAPublicKey(key string) (*rsa.PublicKey, error) {
+	block, val := pem.Decode([]byte(key))
+	if block == nil {
+		// This is supposed to be a public key so we can log
+		logrus.Debugf(string(val))
+		return nil, errors.New("Could not decode public key block")
+	}
+	logrus.Debugf("Public Key Block Type: %s", block.Type)
+
+	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return pub.(*rsa.PublicKey), nil
+}

--- a/vendor/github.com/rancher/secrets-api/pkg/rsautils/rsa.go
+++ b/vendor/github.com/rancher/secrets-api/pkg/rsautils/rsa.go
@@ -1,0 +1,80 @@
+package rsautils
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"io/ioutil"
+)
+
+// Decryptor handles decrypting messages
+type Decryptor interface {
+	Decrypt(cipherText string) ([]byte, error)
+}
+
+type rsaDecryptor struct {
+	privateKeyPath string
+	key            *rsa.PrivateKey
+}
+
+//NewRSADecryptorKeyFromFile returns an RSA decryptor
+func NewRSADecryptorKeyFromFile(privateKeyPath string) (Decryptor, error) {
+	key, err := loadPrivateKeyFromFile(privateKeyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return rsaDecryptor{
+		privateKeyPath: privateKeyPath,
+		key:            key,
+	}, nil
+}
+
+func NewRSADecryptorKeyFromString(privateKey string) (Decryptor, error) {
+	key, err := loadPrivateKeyFromString(privateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return rsaDecryptor{
+		privateKeyPath: "",
+		key:            key,
+	}, nil
+}
+
+//Decrypt implments the decryptor interface
+func (r rsaDecryptor) Decrypt(cipherText string) ([]byte, error) {
+	return rsaDecrypt(r.key, cipherText)
+}
+
+func loadPrivateKeyFromFile(keyPath string) (*rsa.PrivateKey, error) {
+	keyData, err := ioutil.ReadFile(keyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	block, _ := pem.Decode(keyData)
+	if block == nil {
+		return nil, errors.New("Could not decode private key. Is it PEM format?")
+	}
+
+	return x509.ParsePKCS1PrivateKey(block.Bytes)
+}
+
+func loadPrivateKeyFromString(keyString string) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode([]byte(keyString))
+	return x509.ParsePKCS1PrivateKey(block.Bytes)
+}
+
+func rsaDecrypt(priv *rsa.PrivateKey, cipherText string) ([]byte, error) {
+	data, err := base64.StdEncoding.DecodeString(cipherText)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	return rsa.DecryptOAEP(sha256.New(), rand.Reader, priv, data, []byte(""))
+}


### PR DESCRIPTION
The server RSA encrypts the token with the hosts UUID. In order for the requester to have access to the token, they must also have access to the private key on the host matching the HostUUID.