### PR TITLE
Wrong token accessor was being used

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -34,6 +34,8 @@ func CreateTokenRequest(rw http.ResponseWriter, req *http.Request) (int, error) 
 	if err != nil {
 		return http.StatusInternalServerError, err
 	}
+
+	logrus.Debugf("sending intermediate token with accessor: %s", vtr.Accessor)
 	apiContext.Write(vtr)
 
 	return http.StatusOK, nil
@@ -110,7 +112,7 @@ func newVerifiedRevokeTokenRequest(req *http.Request) (*VaultTokenExpireInput, e
 	}
 
 	if verified {
-		logrus.Debugf("VERIFIED: %s", verified)
+		logrus.Debugf("verified signature from host: %s", msg.HostUUID)
 		return msg, nil
 	}
 

--- a/server/vault.go
+++ b/server/vault.go
@@ -72,7 +72,7 @@ func (vc *VaultClient) NewWrappedVaultToken(policies []string) (*IntermediateTok
 		return token, err
 	}
 
-	token.Accessor = sec.WrapInfo.Accessor
+	token.Accessor = sec.WrapInfo.WrappedAccessor
 	token.Token = sec.WrapInfo.Token
 
 	return token, nil

--- a/signature/sign.go
+++ b/signature/sign.go
@@ -62,7 +62,7 @@ func LoadRSAPublicKey(key string) (*rsa.PublicKey, error) {
 
 func timeWindowExpired(ts *time.Time) bool {
 	duration := time.Since(*ts)
-	logrus.Debugf("duration: %s", duration)
+	logrus.Debugf("signature timestamp lapsed time: %s", duration)
 	if duration > TimeWindow {
 		return true
 	}

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -106,7 +106,7 @@ func (v *FlexVol) Attach(options map[string]interface{}) (string, error) {
 
 	err = writeToken(token.EncryptedToken, options)
 	if err != nil {
-		logrus.Errorf("failed to write token: %s to disk. calling revoke.", err)
+		logrus.Errorf("failed to write token: %s to volume. calling revoke.", err)
 		makeTokenRevokeRequest(token.Accessor)
 		return dev, err
 	}


### PR DESCRIPTION
This fixes rancher/rancher#10550.

The wrong accessor was being passed down to the volume driver, and then revoke would fail because it didn't have the correct info.