### PR TITLE
per container volume check

### DIFF
--- a/rancher/rancher.go
+++ b/rancher/rancher.go
@@ -42,3 +42,27 @@ func GetRancherHostPublicKey(rClient *client.RancherClient, hostUUID string) (st
 
 	return "", fmt.Errorf("host: %s not found", hostUUID)
 }
+
+func GetVolumeTemplate(rclient *client.RancherClient, volumeName string) (*client.VolumeTemplate, error) {
+	volumeTemplate := &client.VolumeTemplate{}
+
+	volumes, err := rclient.Volume.List(&client.ListOpts{
+		Filters: map[string]interface{}{
+			"name": volumeName,
+		},
+	})
+	if err != nil {
+		return volumeTemplate, err
+	}
+
+	if len(volumes.Data) > 0 {
+		if volumes.Data[0].VolumeTemplateId == "" {
+			return volumeTemplate, fmt.Errorf("no volume template, per_container: true likely not set")
+		}
+
+		err = rclient.GetLink(volumes.Data[0].Resource, "volumeTemplate", volumeTemplate)
+		return volumeTemplate, err
+	}
+
+	return volumeTemplate, fmt.Errorf("no volumes found")
+}

--- a/server/types.go
+++ b/server/types.go
@@ -14,9 +14,10 @@ type errObj struct {
 
 type VaultTokenInput struct {
 	client.Resource
-	Policies  string `json:"policies"`
-	HostUUID  string `json:"hostUUID"`
-	TimeStamp string `json:"timestamp"`
+	Policies   string `json:"policies"`
+	HostUUID   string `json:"hostUUID"`
+	TimeStamp  string `json:"timestamp"`
+	VolumeName string `json:"volumeName"`
 }
 
 type verifiedVaultTokenInput struct {


### PR DESCRIPTION
This PR adds a check to ensure that the volume is defined with `per_container: true`
This will also attempt to revoke any previous accessors when attaching the volume to a new container.