### PR TITLE
More revoking

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -5,7 +5,7 @@ COPY entrypoint.sh /entrypoint.sh
 COPY secrets-bridge-v2 /usr/bin/
 COPY secrets-bridge-v2-server /usr/bin/
 
-ADD https://raw.githubusercontent.com/rancher/rancher/master/server/bin/update-rancher-ssl /usr/bin/update-rancher-ssl
+ADD https://raw.githubusercontent.com/rancher/rancher/v1.6/server/bin/update-rancher-ssl /usr/bin/update-rancher-ssl
 RUN chmod +x /usr/bin/update-rancher-ssl /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
This PR makes the following changes:
1. Write the accessor Token locally into the tmpfs volume. This is in addition to storing the accessor on the volume. 
2. During the unmount call, the driver will now try and revoke the token immediately by getting the accessor from the local volume.

In addition to this new revoke flow, the volume driver also revokes the token on Detachment of the volume. This is only called when the entire stack is deleted in Rancher. The Attach command also tries to revoke tokens for accessors that are found on the volume in Rancher's database.

Bug fix:
Rancher/Rancher repository format changed with the merge of 2.0. That change broke the Docker build for the container. Updated the Dockerfile to pull from v1.6 branch.

